### PR TITLE
Took out flag preventing newlines in error messages in init.sh

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -15,7 +15,7 @@ fi
 echo "Checking for Node version ${NODE_VERSION}"
 node -v | grep ${NODE_VERSION} >/dev/null 2>&1
 if [[ $? != 0 ]]; then
-    echo -n "Node version ${NODE_VERSION} is not installed"
+    echo "Node version ${NODE_VERSION} is not installed"
     exit
 fi
 
@@ -23,7 +23,7 @@ fi
 echo "Checking for Ruby version ${RUBY_VERSION}"
 ruby -v | grep ${RUBY_VERSION} >/dev/null 2>&1
 if [[ $? != 0 ]]; then
-    echo -n "Ruby version ${RUBY_VERSION} is not installed"
+    echo "Ruby version ${RUBY_VERSION} is not installed"
     exit
 fi
 
@@ -34,7 +34,7 @@ p=$(eval npm list -g | grep grunt-cli)
 echo "Checking for grunt-cli"
 npm -v grunt-cli >/dev/null 2>&1
 if [[ $? != 0 ]]; then
-    echo -n "grunt-cli is not installed"
+    echo "grunt-cli is not installed"
 elif [[ ${p//[^0-9_.]/} = 0 ]]; then
   echo "grunt-cli isn't installed globally"
 


### PR DESCRIPTION
Init.sh would print an error message in bash then follow with the
prompt on the same line. Changed this to have the prompt show up
on the next line.
