### PR TITLE
Start a _docs/ directory of Markdown files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,42 +7,7 @@
   - fork us, fix an issue and submit a merge request
   - refactor suboptimal code
 
--- 
-  
-### Fork, then clone the repo:
-  ```bash
-    git clone git@github.com:your-username/open-source-club-website.git
-    cd open-source-club-website
-  ```
 
---
-
-### Dependencies:
-  - ruby `v2.2.3`
-  - node.js `v4.2.6`
-  
---
-
-### Set up your machine:
-  ```
-  ./init.sh
-  ```
-
---
-
-### Build site locally and run development server:
-  ```bash
-    grunt serve
-    # once compiled the site will be accessible at localhost:4040
-  ```
-
-##### OR
-  
-### Build site locally:
-  ```
-    grunt build
-  ```
-  
 ##### Specify Environment
 
 currently there are three different environments
@@ -74,24 +39,7 @@ Example
 
 --
 
-### Author a new post
-  ```bash
-    ./_helpers/new-post.sh
-  ```
-  
-  **Posts that do not follow this template will be rejected**
-  
-  Meeting announcements **must** contain the following information:
-    - meeting time
-    - building and room number
-    - meeting topic
-    - topic description
-  
-  when sharing email addresses in posts, refer to the following snippet:
-  ```md
-    [officers@opensource.osu.edu](mailto:officers@opensource.osu.edu)
-  ```
-  
+ 
 #### Attaching presenations
   
   If you wish to provide a link to your presentation in your post (we suggest `.pdf`)
@@ -133,6 +81,8 @@ Some things that will increase the chance that your pull request is accepted:
 [commit]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 
 --
+
+## Style Guide
 
 ### Formatting
 

--- a/README.md
+++ b/README.md
@@ -8,49 +8,8 @@
 
 This is our repository for our club's [website](https://opensource.osu.edu). It's built with [Jekyll](https://github.com/jekyll/jekyll), [Jade](https://github.com/jadejs/jade), [Sass](https://github.com/sass/sass), [Coffeescript](https://github.com/jashkenas/coffeescript), and [Grunt](https://github.com/gruntjs/grunt).
 
+## Documentation
 
-[contributing](https://github.com/OSUOSC/open-source-club-website/blob/master/.github/CONTRIBUTING.md)
+- [Deploying](_docs/deploying.md)
 
-[staging site](https://osuosc.github.io/open-source-club-website/)
-
---
-
-
-##### Deploying to Github Pages
-
-Our staging environment is currently utilizing Github Pages. Anyone can deploy
-their own instance of our site in the matter of seconds, without additional setup.
-
-If you haven't already go ahead and fork our repository.
-
-execute the following command to automatically compile and deploy the site to Github Pages.
-*you will have to type in your github credentials once the script is nearing completion*
-
-Once completed the site can be found at `https://<username>.github.io/open-source-club-website/`
-
-for example if your github username was `foo`, your site could be reached at `https://foo.github.io/open-source-club-website/`
-
----
-
-execute the following command to automatically compile and deploy the site to Github Pages
-
-```bash
-bundle exec rake deploy:ghpages
-```
----
-
-
-##### Deploying to OSC servers
-
-Only authorized users may deploy to our servers, since it requires access to the
-`build` user on web3 (one of our servers). To request access, contact the club's
-system administrator with your public SSH key.
-
-
-```bash
-bundle exec rake deploy:web3
-```
-
-After running the rake task, the site will automatically be built and deployed
-on our servers. If by chance something goes wrong, immediately contact the
-club's system administrator.
+To learn more about getting this repository set up on your computer or to find instructions on how to contribute new posts, check out the [contributing](https://github.com/OSUOSC/open-source-club-website/blob/master/.github/CONTRIBUTING.md) file.

--- a/_docs/deploying.md
+++ b/_docs/deploying.md
@@ -1,0 +1,38 @@
+## Deploying to Github Pages
+
+
+Our [staging site](https://osuosc.github.io/open-source-club-website/) is is on Github Pages.
+Anyone can deploy their own instance of our site in the matter of seconds, without additional setup.
+
+If you haven't already, go ahead and [fork our repository](https://help.github.com/articles/fork-a-repo/).
+
+
+Once completed the site can be found at `https://<username>.github.io/open-source-club-website/`
+
+
+---
+
+execute the following command to automatically compile and deploy the site to Github Pages
+*you will have to type in your github credentials once the script is nearing completion*
+
+```bash
+bundle exec rake deploy:ghpages
+```
+
+---
+
+
+## Deploying to OSC servers
+
+Only authorized users may deploy to our servers, since it requires access to the
+`build` user on web3 (one of our servers). To request access, contact the club's
+system administrator with your public SSH key.
+
+
+```bash
+bundle exec rake deploy:web3
+```
+
+After running the rake task, the site will automatically be built and deployed
+on our servers. If by chance something goes wrong, immediately contact the
+club's system administrator.

--- a/_docs/new-post.md
+++ b/_docs/new-post.md
@@ -1,0 +1,51 @@
+## New posts
+
+To create a new post, run `/_helpers/new-post.sh` on the command line, or copy an existing post in `/_posts/` and edit it.
+
+Meeting announcements must contain the following information:
+
+- meeting time
+- building and room number
+- meeting topic
+- topic description
+
+If you are manually creating the post, the date in the filename will be the date that the post is published on the site.
+
+**Posts that do not follow this template will be rejected**
+
+When sharing email addresses in posts, refer to the following snippet:
+
+```md
+[officers@opensource.osu.edu](mailto:officers@opensource.osu.edu)
+```
+
+## Rebuilding the site after creating a new post
+
+There are two ways to do this. You can rebulid the site, which only updates the files, or you can rebuild the site and run a server to watch for future changes.
+
+### Build site locally and run development server
+
+This option allows you to view your changes at http://localhost:4040
+
+After getting [set up](./setup.md), run the following command from the root of the project.
+
+  ```bash
+    grunt serve
+  ```
+
+To kill the server, press `<control-c>` in your terminal.
+
+### Build site locally:
+
+This option only recompiles the site's files, and does not run a local webserver.
+  ```
+    grunt build
+  ```
+
+## Run the tests
+
+After creating a new post, run `grunt test`.
+
+## Submit a pull request
+
+When you're happy with your new post, commit it and [submit a pull request](.github/CONTRIBUTING.md).

--- a/_docs/setup.md
+++ b/_docs/setup.md
@@ -1,0 +1,24 @@
+## Getting the website set up on your computer
+
+1. Fork the repository.
+2. Clone the repository from your fork:
+
+	```bash
+	git clone git@github.com:your-username/open-source-club-website.git
+	cd open-source-club-website
+	```
+
+3. Install the dependencies:
+
+  - ruby `v2.2.3`
+  - node.js `v4.2.6`
+
+3. Run the setup scripts
+
+	```bash
+	./init.sh
+	npm install -g grunt-cli bower jade
+	bower install
+	npm install
+	```
+


### PR DESCRIPTION
This implements some of #190, but will hopefully become part of a thriving ecosystem of `_docs/`
## Changes
- creates `/_docs/`
- WIP work on moving stuff out of the contributing file
- more-prominent link to docs in README.md
## To do
- [x] document build environment usage
- [x] break everything else out of `.github/CONTRIBUTING.md`
- [x] Fill out `README.md` with docs table of contents
