### PR TITLE
init doesn't exit if git-lfs doesn't exist

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -6,7 +6,6 @@ if [[ $? != 0 ]]; then
     echo "Git LFS not found."
     echo "Install it using your package manager or at https://git-lfs.github.com/."
     echo "Until this is done, downloads/ will appear strangely."
-    exit
 fi
 
 # remove cached node modules if they exisit

--- a/init.sh
+++ b/init.sh
@@ -23,3 +23,4 @@ echo 'Checking for bundler gem'
 if ! [ $(gem list bundler -i) ]; then
   gem install bundler
 fi
+


### PR DESCRIPTION
Changes proposed in the pull request:
-Got rid of the exit for checking git-lfs in init.sh as this is not a deal breaker and the consequences are discussed in the warning given

<!--  DON'T REMOVE THIS -->

@OSUOSC/website-team 

<!------------------------>
