### PR TITLE
updated gems to latest versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source "https://rubygems.org"
 
-gem 'jekyll', '~> 3.1.3'
+gem 'jekyll', '~> 3.2.1'
 gem 'jekyll-paginate', '~> 1.1.0', github: 'egladman/jekyll-paginate'
-gem 'jekyll-sitemap', '~> 0.10.0'
+gem 'jekyll-sitemap', '~> 0.11.0'
 gem 'jekyll-last-modified-at', '~> 0.3.4'
 gem 'jekyll-feed', '~> 0.5.1'
-gem 'rake', '~> 11.1.2'
+gem 'rake', '~> 11.2.2'
 gem 'colored', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,16 +7,19 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    colorator (0.1)
+    addressable (2.4.0)
+    colorator (1.1.0)
     colored (1.2)
-    ffi (1.9.10)
-    jekyll (3.1.3)
-      colorator (~> 0.1)
+    ffi (1.9.14)
+    forwardable-extended (2.6.0)
+    jekyll (3.2.1)
+      colorator (~> 1.0)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
       kramdown (~> 1.3)
       liquid (~> 3.0)
       mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
     jekyll-feed (0.5.1)
@@ -24,20 +27,23 @@ GEM
       jekyll
     jekyll-sass-converter (1.4.0)
       sass (~> 3.4)
-    jekyll-sitemap (0.10.0)
-    jekyll-watch (1.4.0)
+    jekyll-sitemap (0.11.0)
+      addressable (~> 2.4.0)
+    jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
-    kramdown (1.11.1)
+    kramdown (1.12.0)
     liquid (3.0.6)
-    listen (3.0.7)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9.7)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
-    rake (11.1.2)
+    pathutil (0.14.0)
+      forwardable-extended (~> 2.6)
+    rake (11.2.2)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
-    rouge (1.10.1)
+    rouge (1.11.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
 
@@ -46,12 +52,12 @@ PLATFORMS
 
 DEPENDENCIES
   colored (~> 1.2)
-  jekyll (~> 3.1.3)
+  jekyll (~> 3.2.1)
   jekyll-feed (~> 0.5.1)
   jekyll-last-modified-at (~> 0.3.4)
   jekyll-paginate (~> 1.1.0)!
-  jekyll-sitemap (~> 0.10.0)
-  rake (~> 11.1.2)
+  jekyll-sitemap (~> 0.11.0)
+  rake (~> 11.2.2)
 
 BUNDLED WITH
-   1.11.2
+   1.12.5


### PR DESCRIPTION
I updated the ruby gems to their latest versions. 

Changes proposed in the pull request:
- jekyll v3.1.1 to v3.2.1
- jekyll-sitemap v0.10.0 to v0.11.0
- rake v11.1.2 to v11.2.2

<!--  DON'T REMOVE THIS -->

@OSUOSC/website-team 

<!------------------------>
