### PR TITLE
Fixed Ted Li's email address in officers

### DIFF
--- a/_info/02-officers.md
+++ b/_info/02-officers.md
@@ -7,7 +7,7 @@ redirect_from:
 ---
 
 #### 2017-2018
-* Benevolent Dictator - Ted Li (li.9668@osu.edu)
+* Benevolent Dictator - Ted Li (li.6998@osu.edu)
 * Vice President - Andrew `smacz` Cziryak (cziryak.1@osu.edu)
 * Treasurer - Jack Moore (moore.3337@osu.edu)
 * System Administrator - John `EDT` Markiewicz (markiewicz.22@osu.edu)


### PR DESCRIPTION
It does what the title says. Email should be li.6998@osu.edu according to both history and OSU findpeople

<!--  DON'T REMOVE THIS -->
@OSUOSC/website-team 
<!------------------------>
