### PR TITLE
Put useful title on link to benlk's personal site

### DIFF
--- a/_info/05-personal_sites.md
+++ b/_info/05-personal_sites.md
@@ -9,6 +9,6 @@ The Open Source Club hosts Club Members' personal sites on request on our intern
 ## Sites:
 
 - [al3k]({{ '~al3k' | absolute_url }})
-- [benlk]({{ '~benlk' | absolute_url }})
+- [Ben Keith's oral history of bots in #osuosc]({{ '~benlk' | absolute_url }})
 - [malide]({{ '~malide' | absolute_url }})
 - [smacz]({{ '~smacz' | absolute_url }})


### PR DESCRIPTION
This is tangential to https://github.com/OSUOSC/website/pull/269/.

Changes proposed in the pull request:
- adds a readable title to the link.


<!--  DON'T REMOVE THIS -->
@OSUOSC/website-team 
<!------------------------>
