### PR TITLE
Change Reciever to Receiver

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ info:
     btn_label: "Connect Here"
   - image_path: /assets/osuosc/mobo.jpg
     title: "Hardware"
-    excerpt: "The Open Source Club has many types of hardware, from Bluetooth Recievers to Raspberry Pis for its members to borrow at will."
+    excerpt: "The Open Source Club has many types of hardware, from Bluetooth Receivers to Raspberry Pis for its members to borrow at will."
   - image_path: assets/osuosc/events.svg
     image_width: 69%
     title: "Take a look at our recent and upcoming events"


### PR DESCRIPTION
I have never heard of a "Bluetooth Reciever", do you mean a "Bluetooth Receiver"?

Fixes "Bluetooth Reciever".

Changes proposed in the pull request:
- "Bluetooth Reciever" -> "Bluetooth Receiver"

@OSUOSC Website Team