### PR TITLE
Site services status update blog post

### DIFF
--- a/_posts/2017-12-01-status.md
+++ b/_posts/2017-12-01-status.md
@@ -1,0 +1,42 @@
+---
+layout: single
+multipage: false
+date: 2017-10-26
+collection: news
+content: cheese
+---
+
+This post shouldn't be published until this post is edited and the questions have been answered or removed.
+
+<dl>
+<dt>What is the status of club services, including idle2, stallman, and user homedir websites?</dt>
+<dd>
+  <ul>
+    <li>opensource.osu.edu: up</li>
+    <li>ldap: down</li>
+    <li>mail: down</li>
+    <li>homedirs: down</li>
+    <li>idle2/stallman/ssh: down</li>
+  </ul>
+</dd>
+
+<dt>What happened to the club services?</dt>
+<dd>Something broke. The CSE department rebooted our server by pressing the power key instead of performing a safe reboot, and as a result there was filesystem corruption.
+</dd>
+
+<dt>Why has it taken so long to get back up?</dt>
+<dd>
+  <p>We're having to go through the approvals process again.</p>
+  <p>LDAP is broken.</p>
+  <p>The filesystem isn't working.</p>
+  <p>We're students; the club isn't a job and we have other things to do.</p>
+</dd>
+
+<dt>Why did it take 3 months to get the website back up?</dt>
+<dd>Answer</dd>
+
+</dl>
+
+We don't have an expected resolution time/This is expected to be solved by June 2018.
+
+

--- a/_posts/2017-12-01-status.md
+++ b/_posts/2017-12-01-status.md
@@ -22,6 +22,16 @@ Since then, we've been working to get it up and running again, and as you can se
 
 - The website
 
+## What's broken?
+
+- ???
+
+If you can help us with these things, get in touch at tktk
+
+## How can former users reclaim their files?
+
+tktk
+
 ## What does the future hold?
 
 We're working on things.

--- a/_posts/2017-12-01-status.md
+++ b/_posts/2017-12-01-status.md
@@ -1,42 +1,29 @@
 ---
-layout: single
-multipage: false
-date: 2017-10-26
-collection: news
-content: cheese
+title: An Update on Services
+date: 2017-12-01
+collections: news
 ---
 
-This post shouldn't be published until this post is edited and the questions have been answered or removed.
+In the summer of 2017 (exact date?) the club computer network failed.
 
-<dl>
-<dt>What is the status of club services, including idle2, stallman, and user homedir websites?</dt>
-<dd>
-  <ul>
-    <li>opensource.osu.edu: up</li>
-    <li>ldap: down</li>
-    <li>mail: down</li>
-    <li>homedirs: down</li>
-    <li>idle2/stallman/ssh: down</li>
-  </ul>
-</dd>
+Since then, we've been working to get it up and running again, and as you can see, the website is up and running.
 
-<dt>What happened to the club services?</dt>
-<dd>Something broke. The CSE department rebooted our server by pressing the power key instead of performing a safe reboot, and as a result there was filesystem corruption.
-</dd>
+## How did the website die?
 
-<dt>Why has it taken so long to get back up?</dt>
-<dd>
-  <p>We're having to go through the approvals process again.</p>
-  <p>LDAP is broken.</p>
-  <p>The filesystem isn't working.</p>
-  <p>We're students; the club isn't a job and we have other things to do.</p>
-</dd>
+- ETS pressed the power button.
+- disk corruption, and as a result ...
+	- LDAP is dead, and as a result ...
+	- homedirs aren't served
+	- user homedir websites as described at http://opsnsource.osu.edu/info/personal-sites/ are down
+	- no mail
+- no one can log into network machines including stallman and idle2
 
-<dt>Why did it take 3 months to get the website back up?</dt>
-<dd>Answer</dd>
+## What works now?
 
-</dl>
+- The website
 
-We don't have an expected resolution time/This is expected to be solved by June 2018.
+## What does the future hold?
 
+We're working on things.
 
+The last line of the post appears to be dropped somewhere in the parse, so I'm going to just put this comment here as the last line.


### PR DESCRIPTION
Changes proposed in the pull request:
- a post explaining what happened to club servers, what their status is, and what the future holds.

As I wrote in my email to officers:

> I've been bugging @smacz42  and other officers (but primarily smacz) since the disruption for a mechanism by which updates on services recovery could be posted on the club website, possibly including starting a whole separate website. Andrew called me out on that today: I had been asking for messaging methods without asking for the status, and asking for resolution timelines without asking about the reasons for the issues.

> I was wrong. I should've asked different questions, and not treated the club servers like a service the club was obligated to provide to its present and past members. And instead of pestering people for updates, I should've worked to understand the problem, and to explain it to myself and other club users. My approach was wrong, and I apologize.

> As part of making up for that, I'd like to write a post for the club website that explains the status of club services, the problems and their causes. If any of you are open to this, I have a few questions to start the conversation.

I do want to better understand the problem. This pull request introduces the bare bones of the post necessary to get it to render, but doesn't have any more content than an outline of what I hope it could cover. I'll be adding to it as I better understand the problem and history.

If you have information to ontribute, you can get in touch with me in this PR, on IRC under the handle `Boom_Farmer`, or by email at keith.146.

<!--  DON'T REMOVE THIS -->
@OSUOSC/website-team 
<!------------------------>
